### PR TITLE
Updated getCharactersWithPlayer pipeline

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ publishing {
         register("mavenJava", MavenPublication::class) {
             groupId = "org.wagham"
             artifactId = "kabot-db-connector"
-            version = version
+            version = version.toString().replace("-SNAPSHOT", "")
             from(components["java"])
         }
     }

--- a/src/main/kotlin/org/wagham/db/pipelines/characters/CharactersWithPlayer.kt
+++ b/src/main/kotlin/org/wagham/db/pipelines/characters/CharactersWithPlayer.kt
@@ -1,11 +1,14 @@
 package org.wagham.db.pipelines.characters
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.mongodb.client.model.UnwindOptions
 import org.bson.Document
 import org.bson.codecs.pojo.annotations.BsonId
 import org.bson.conversions.Bson
 import org.litote.kmongo.lookup
 import org.litote.kmongo.match
+import org.litote.kmongo.project
+import org.litote.kmongo.unwind
 import org.wagham.db.enums.CharacterStatus
 import org.wagham.db.models.Building
 import org.wagham.db.models.Errata
@@ -14,7 +17,7 @@ import java.util.*
 
 data class CharacterWithPlayer (
     @BsonId val name: String,
-    val player: List<Player> = listOf(),
+    val player: Player,
     val race: String?,
     val territory: String?,
     @JsonProperty("class") val characterClass: String?,
@@ -34,13 +37,21 @@ data class CharacterWithPlayer (
     val proficiencies: List<String> = listOf()
 )
 
+
 class CharactersWithPlayer {
     companion object {
 
         fun getPipeline(status: CharacterStatus?): List<Bson> {
             val matchStep = if (status != null) listOf(match(Document(mapOf("status" to status))))
                 else listOf()
-            return matchStep + lookup("players", "player", "_id", "player")
+            return matchStep +
+                    lookup("players", "player", "_id", "player") +
+                    unwind("\$player", UnwindOptions()
+                        .includeArrayIndex("unwindCounter")
+                        .preserveNullAndEmptyArrays(false)) +
+                    match(Document(mapOf("unwindCounter" to 0))) +
+                    project(Document(mapOf("unwindCounter" to 0)))
+
         }
 
     }


### PR DESCRIPTION
The getCharactersWithPlayer pipeline now returns just a single player per character instead of the list.
The characters with no players are filtered out